### PR TITLE
Added valid_to and valid_from

### DIFF
--- a/src/database/entity/flex-version-entity.ts
+++ b/src/database/entity/flex-version-entity.ts
@@ -81,4 +81,32 @@ export class FlexVersions extends BaseDto {
         }
         return queryObject;
     }
+
+    /**
+     * Query where the valid_from and valid_to dates are overlapping
+     * Eg.
+     * If Record has valid_from: 23-Mar-2023 and valid_to:23-Apr-2023
+     *  {valid_from:01-Apr-2023, valid_to: 26-Apr-2023} : Invalid
+     *  {valid_from:20-Mar-2023, valid_to: 26-Apr-2023} : Invalid
+     *  {valid_from:20-Mar-2023, valid_to: 10-Apr-2023} : Invalid
+     *  {valid_from:24-Mar-2023, valid_to: 10-Apr-2023} : Invalid
+     *  {valid_from:24-Mar-2023, valid_to: 10-Apr-2023} : Invalid
+     *  {valid_from:10-Mar-2023, valid_to: 22-Mar-2023} : Valid
+     *  Same ord_id and service_id with the following condition
+     *  input_valid_from >= record_valid_from && input_valid_to 
+     */
+    getOverlapQuery(): QueryConfig {
+        
+        const fromDate = new Date(this.valid_from);
+        const toDate = new Date(this.valid_to);
+        
+        const queryObject = {
+            text:`SELECT tdei_record_id from public.flex_versions where 
+            tdei_org_id = $1 
+            AND tdei_service_id = $2 
+            AND (valid_from,valid_to) OVERLAPS ($3 , $4)`,
+            values:[this.tdei_org_id,this.tdei_service_id,fromDate, toDate]
+        };
+        return queryObject;
+    }
 }

--- a/src/exceptions/http/http-exceptions.ts
+++ b/src/exceptions/http/http-exceptions.ts
@@ -6,6 +6,12 @@ export class DuplicateException extends HttpException {
     }
 }
 
+export class OverlapException extends HttpException {
+    constructor(name:string){
+        super(400,`Given record overlaps with tdeirecord ${name} in the system.`);
+    }
+}
+
 export class UnAuthenticated extends HttpException {
     constructor() {
         super(401, `User not authenticated/authorized to perform this action.`);

--- a/src/service/gtfs-flex-service.ts
+++ b/src/service/gtfs-flex-service.ts
@@ -8,7 +8,7 @@ import flexDbClient from "../database/flex-data-source";
 import { environment } from "../environment/environment";
 import UniqueKeyDbException from "../exceptions/db/database-exceptions";
 import HttpException from "../exceptions/http/http-base-exception";
-import { DuplicateException } from "../exceptions/http/http-exceptions";
+import { DuplicateException, OverlapException } from "../exceptions/http/http-exceptions";
 import { GtfsFlexDTO } from "../model/gtfs-flex-dto";
 import { FlexQueryParams } from "../model/gtfs-flex-get-query-params";
 import { ServiceDto } from "../model/service-dto";
@@ -97,7 +97,12 @@ class GtfsFlexService implements IGtfsFlexService {
                 console.log(service.tdei_service_id);
             }
             
-
+            // Check if there is a record with the same date
+            const queryResult =  await flexDbClient.query(flexInfo.getOverlapQuery());
+            if(queryResult.rowCount > 0) {
+                const recordId = queryResult.rows[0]["tdei_record_id"];
+                throw new OverlapException(recordId);
+            }
             await flexDbClient.query(flexInfo.getInsertQuery());
 
             let flex = GtfsFlexDTO.from(flexInfo);


### PR DESCRIPTION

Overlap checking is done.

- Additional check will be made in the metadata validation. 
- This check will do an overlap check with the existing system for valid_to and valid_from. (service_id and org_id)

Caveats
- Same date overlap may not be considered (eg. if valid_to of existing record is 12 Mar 2023 9:45 AM and the new record with valid_from 12 Mar 2023 9:00AM, it will not consider overlap). This is there only till date (bug to be put up)

Testing
- 2bf7f70127b146cbb96319b5d39ada93 is first inserted and then checked with 445a68b318e44f56a7ec2d5bb4d9b688 (overlap)
- Non overlaps are already done. 
NOTE:
- This might considerably change the payloads of flex and pathways upload. The valid_to and valid_from parameters have to be maintained dynamically for end to end testing. This may break some of the existing testing functionalities.