### PR TITLE
Refactor event bus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ COPY package.json ./
 #COPY .env ./
 COPY tsconfig.json ./
 COPY src ./src
-COPY config ./config
 RUN ls -a
 RUN npm install
 RUN npm run build

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest-fetch-mock": "^3.0.3",
     "lodash": "4.17.21",
     "node-fetch": "^2.6.7",
-    "nodets-ms-core": "0.0.7",
+    "nodets-ms-core": "0.0.8",
     "pg": "^8.8.0",
     "reflect-metadata": "^0.1.13"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,7 @@ class App {
     }
 
     private subscribeUpload() {
+        this.eventBusService = new EventBusService();
         this.eventBusService.subscribeTopic();
     }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import bodyParser from "body-parser";
 import { IController } from "./controller/interface/IController";
 import helmet from "helmet";
 import { Core } from "nodets-ms-core";
-import eventBusService from "./service/event-bus-service";
+import { EventBusService } from "./service/event-bus-service";
 import { unhandledExceptionAndRejectionHandler } from "./middleware/unhandled-exception-rejection-handler";
 import { errorHandler } from "./middleware/error-handler-middleware";
 import flexDbClient from "./database/flex-data-source";
@@ -12,6 +12,7 @@ import flexDbClient from "./database/flex-data-source";
 class App {
     public app: express.Application;
     public port: number;
+    private eventBusService!:  EventBusService;
 
     constructor(controllers: IController[], port: number) {
         this.app = express();
@@ -34,7 +35,7 @@ class App {
     }
 
     private subscribeUpload() {
-        eventBusService.subscribeTopic();
+        this.eventBusService.subscribeTopic();
     }
 
     private initializeMiddlewares() {

--- a/src/service/interface/event-bus-service-interface.ts
+++ b/src/service/interface/event-bus-service-interface.ts
@@ -5,5 +5,5 @@ export interface IEventBusServiceInterface {
      * Subscribing to the interested topic & subscription to process the queue message
      */
     subscribeTopic(): void;
-    publishingTopic: Topic;
+    //publishingTopic: Topic;
 }

--- a/test/integration/flex.integration.test.ts
+++ b/test/integration/flex.integration.test.ts
@@ -69,7 +69,7 @@ describe("Flex Integration Test", () => {
         //Act
         var eventBusService = new EventBusService();
         eventBusService.publishingTopic = mockPublishingTopic;
-        eventBusService.subscribeTopic();
+        eventBusService.subscribeTopic("temp-validation", "temp-validation-result");
 
         //Assert
         await expect(assertMessage()).resolves.toBeTruthy();
@@ -145,8 +145,4 @@ describe("Flex Integration Test", () => {
         //Assert
         expect(result.status == 200).toBeTruthy();
     }, 15000);
-
-
-    
-
 });

--- a/test/integration/flex.integration.test.ts
+++ b/test/integration/flex.integration.test.ts
@@ -18,6 +18,10 @@ describe("Flex Integration Test", () => {
         done();
     });
 
+    beforeAll(()=>{
+        Core.initialize();
+    })
+
 
     /**
      * Environment dependency
@@ -35,7 +39,7 @@ describe("Flex Integration Test", () => {
         //Arrange
         var messageReceiver!: QueueMessage;
 
-        Core.initialize();
+        
         var topicToSubscribe = Core.getTopic("temp-validation", {
             provider: "Azure"
         });
@@ -145,4 +149,15 @@ describe("Flex Integration Test", () => {
         //Assert
         expect(result.status == 200).toBeTruthy();
     }, 15000);
+
+    test('Verifying the service can access File Storage with file URL ', async () => {
+        Core.initialize();
+        const fileUrl = 'https://tdeisamplestorage.blob.core.windows.net/gtfsflex/2023/FEBRUARY/0b41ebc5-350c-42d3-90af-3af4ad3628fb/valid_c8c76e89f30944d2b2abd2491bd95337.zip';
+        const fileEntity = await Core.getStorageClient()!.getFileFromUrl(fileUrl);
+        const streamData = await fileEntity?.getStream();
+        // const bufferLength = streamData?.read().length;
+        // expect(bufferLength).toBeGreaterThan(0);
+        expect(streamData).toBeTruthy();
+
+    },20000);
 });

--- a/test/test-case-enumeration.md
+++ b/test/test-case-enumeration.md
@@ -88,7 +88,8 @@ describe("{{Component}}", () => {
 
 | Component | Feature Under Test | Scenario | Expectation | Status |
 |--|--|--|--|--|
-| Flex Service | Servicebus Integration | Subscribe to validation result topic to verify servicebus integration| Expect to return message |:white_check_mark:|
-| Flex Service | Permission Request | Verifying auth service hasPermission api integration| Expect to return false |:white_check_mark:|
+| Flex Service | Servicebus Integration | Subscribe to a validation topic | Expect to process the message and return response in target topic |:white_check_mark:|
+| Flex Service | Permission Request | Verifying auth permission with invalid credentials| Expect to resolve as false (and not throw exception) |:white_check_mark:|
 | Flex Service | Auth service | Verifying auth service generate secret api integration | Expect to return HTTP status 200 |:white_check_mark:|
 | Flex Service | Get Service | Verifying service get service api integration | Expect to return HTTP status 200 |:white_check_mark:|
+| Flex Service | Storage Integration | Verify that when service accesses file from storage | Expect that the file contains data | |

--- a/test/unit/flex.service-bus.test.ts
+++ b/test/unit/flex.service-bus.test.ts
@@ -4,7 +4,9 @@ import { GtfsFlexDTO } from "../../src/model/gtfs-flex-dto";
 import { getMockTopic, mockCore, mockQueueMessageContent } from "../common/mock-utils";
 import { QueueMessage } from "nodets-ms-core/lib/core/queue";
 import { Topic } from "nodets-ms-core/lib/core/queue/topic";
-import eventBusService from "../../src/service/event-bus-service";
+import { EventBusService } from "../../src/service/event-bus-service";
+
+var eventBusService = new EventBusService();
 
 // group test using describe
 describe("Queue message service", () => {


### PR DESCRIPTION
Integration testing changes.
Spliced the integration and unit testing
Running npm test will just run unit tests
Running npm run test:integration will run integration test

couple of refactoring to code to support testing and de-coupling